### PR TITLE
Передаю результат работы borschika в deferred.resolve

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -20,7 +20,7 @@ exports.writeFile = function(output, res) {
             // output res to stdout
             if (output === process.stdout) {
                 output.write(res);
-                return Q.resolve();
+                return Q.resolve(res);
             }
 
             // write res to writable stream of opened file
@@ -31,11 +31,11 @@ exports.writeFile = function(output, res) {
             });
 
             output.once('close', function() {
-                defer.resolve();
+                defer.resolve(res);
             });
 
             output.once('end', function() {
-                defer.resolve();
+                defer.resolve(res);
             });
 
             output.write(res);

--- a/test/js-node-api.js
+++ b/test/js-node-api.js
@@ -1,0 +1,61 @@
+var ASSERT = require("assert");
+
+/**
+ * @desc Test node API interface.
+ * How use borshik in nodejs
+ */
+
+describe('js-node-api:', function() {
+    var PATH = require('path');
+    var FS = require('fs');
+    var BORSCHIK = require('..');
+    var processWrite = process.stdout.write;
+
+    const basePath = PATH.resolve(__dirname, 'js-include');
+
+    var testFileName = 'include1.js';
+    var input = PATH.resolve(basePath, testFileName);
+    var expect = PATH.resolve(basePath, testFileName.replace('.js', '-expect.js'));
+
+    afterEach(function(cb) {
+        process.stdout.write = processWrite;
+        require('child_process').exec('rm -rf ' + basePath + '/*-out.js', function() {
+            cb();
+        });
+    });
+
+    it('should output file content by default in process.stdout', function(cb) {
+
+        process.stdout.write = function(fileContent/*, encoding, fd*/) {
+            processWrite.apply(process.stdout, arguments);
+            process.stdout.write = processWrite;
+
+            ASSERT.equal(fileContent, FS.readFileSync(expect, 'utf-8'));
+        };
+
+        // If we do not pass property `output` borshik by default
+        // write result to process.stdout
+        BORSCHIK.api({
+            'input': input,
+            'comments': false,
+            'freeze': false,
+            'minimize': false,
+            'tech': 'js'
+        }).then(cb.bind(null, null), cb);
+    });
+
+    it('should return file content in promise', function(cb) {
+
+        BORSCHIK.api({
+            'input': input,
+            'comments': false,
+            'freeze': false,
+            'minimize': false,
+            'tech': 'js'
+        })
+        .then(function(fileContent) {
+            ASSERT.equal(fileContent, FS.readFileSync(expect, 'utf-8'));
+        }).then(cb, cb);
+    });
+
+});


### PR DESCRIPTION
Обычно мы ожидаем что в `then` при успехе вернется
результат, что бы потом как то дополнительно обработать его. При таком подходе
можно обойтись без свойства `output`.

Пример:

``` javascript

borschik.api({...}).then(function(fileContent) {
     processContent(fileContent);
});

```
