### PR TITLE
Add borschik.include() syntax

### DIFF
--- a/lib/techs/js.js
+++ b/lib/techs/js.js
@@ -39,7 +39,10 @@ exports.Tech = base.Tech.inherit({
                     .join('|')
                     + '|' +
                     // RegExp to find borschik.link("path/to/image.png")
-                    'borschik\\.link\\([\'"]([^@][^"\']+?)[\'"]\\)',
+                    'borschik\\.link\\([\'"]([^@][^"\']+?)[\'"]\\)'
+                    + '|' +
+                    // RegExp to find borschik.include("path/to/file.js")
+                    'borschik\\.include\\([\'"]([^@][^"\']+?)[\'"]\\)',
                     'g'),
 
                 uniqStr = '\00borschik\00',
@@ -48,8 +51,8 @@ exports.Tech = base.Tech.inherit({
             var includes = [],
                 texts = content
                     // finds /*borschik:include:*/ and "borschik:include:"
-                    .replace(allIncRe, function(_, incObjectFile, incArrayFile, incCommFile, incStrFile, borschikLink) {
-                        var incFile = incObjectFile || incArrayFile || incCommFile || incStrFile;
+                    .replace(allIncRe, function(_, incObjectFile, incArrayFile, incCommFile, incStrFile, borschikLink, borschikInc) {
+                        var incFile = incObjectFile || incArrayFile || incCommFile || incStrFile || borschikInc;
                         if (incFile) {
                             includes.push({
                                 file: _this.pathTo(incFile),


### PR DESCRIPTION
Я сейчас экспериментирую с генерацией code coverage отчёта для тестов через `istanbul`. И сталкиваюсь с некоторыми проблемами. Сейчас у меня остаются сомнения в надёжности того, что после инструментирования кода комментарии с `/*borschik:include:...*/` останутся на своих местах.

Возможно, стоит перейти на plain js синтаксис для описания include при сборке в `bem build`.

PS: подробности про мои эксперименты здесь https://st.yandex-team.ru/ISL-164

/cc @doochik @veged
