### PR TITLE
Windows support when tech loaded from given path

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -75,8 +75,8 @@ function _getTech(tech, use_cwd) {
     }
 
     // load tech from given path
-    // borschik -t ./somepath/tech.js
-    if (/^[\/.]/.test(tech)) {
+    // borschik -t ./somepath/tech.js or borschik -t X:\somepath\tech.js
+    if (/(.+)[\\\/]/.test(tech)) {
         return require(PATH.resolve(tech));
     }
 


### PR DESCRIPTION
Добрый день, коллеги!

Столкнулся с проблемой запуска тестов с измерением покрытия на операционной системе Windows.
При выполнении команды `ISTANBUL_COVERAGE=yes ./node_modules/.bin/enb make specs`
Сборка падает в этом месте:
`[failed] [desktop.specs\my-block\my-block.coverage.spec.js] borschik`
С такой ошибкой:
`Error: Cannot find module 'borschik-tech-C:\pathtomyproject\node_modules\enb-bem-specs\node_modules\borschik-tech-istanbul'`

Проблема оказалась в том, что текущая версия может загружать технологии по пути только для Unix-подобных операционных систем. 

Исправил регулярку. Очень хочется запускать на винде :) 

P.S. При вызове команды `./node_modules/.bin/enb make specs` проблем нет, сборка проходит успешно.