### PR TITLE
fix(css): `processPath` should return path to file

### DIFF
--- a/lib/techs/css.js
+++ b/lib/techs/css.js
@@ -1,4 +1,6 @@
-var base = require('./css-base'),
+var URL = require('url'),
+
+    base = require('./css-base'),
     U = require('../util'),
 
     stringRe = "(?:(?:'[^'\\r\\n]*')|(?:\"[^\"\\r\\n]*\"))",
@@ -56,7 +58,7 @@ exports.Tech = base.Tech.inherit({
                         range: [m.index, allRe.lastIndex - 1]
                     });
                 } else if (srcStringRx.test(m[0])) {
-                    // src=... 
+                    // src=...
                     var src = parseSrc(m[0]);
                     if (U.isLinkProcessable(src)) found.push({
                         type: 'linkSrc',
@@ -106,7 +108,7 @@ exports.Tech = base.Tech.inherit({
          },
 
         processPath: function(path) {
-            return path.replace(/^(.*?)(\?|$)/, '$1');
+            return typeof path === 'string' ? URL.parse(path).pathname : '';
         }
 
     })


### PR DESCRIPTION
The correct path to the file is needed to read or obtain stats.

Before changes the `processPath` method deletes `?` symbol, but not
query part.

**Example:**

```
pathname?x=1
```

**Result before changes:**

```
pathnamex=1
```

**Result after changes:**

```
path
```

The same method did not remove the `hash` part:

**Example:**

```
path#hash
```

**Result before changes:**

```
path#hash
```

**Result after changes:**

```
path
```


`processPath` was added in https://github.com/borschik/borschik/commit/4267461901528bc77c48b0d492d4d19834b3dcb4 commit to:

> Strip the query part of a link before reading a file from disk