### PR TITLE
Drop node 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "engines": [
-    "node >= 0.8.0"
+    "node >= 0.10.0"
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
because you don't have it even in `.travis.yml`