### PR TITLE
fix mkpath on windows

### DIFF
--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -400,7 +400,7 @@ function mkpath(path) {
     dirs.forEach(function(dir) {
         dir = dir || PATH.sep;
         if (dir) {
-            _path = PATH.join(_path, dir);
+            _path = _path ? PATH.join(_path, dir) : dir;
             // fs.mkdirSync('/') raises EISDIR (invalid operation) exception on OSX 10.8.4/node 0.10
             // fs.mkdirSync('D:\\') raises EPERM (operation not permitted) exception on Windows 7/node 0.10
             // not tested in other configurations


### PR DESCRIPTION
It is bad idea to join empty string and drive letter on Windows:

```JS
console.log(require('path').win32.join('', 'D:')); // 'D:.'
```